### PR TITLE
Changed session query, renamed tables, test

### DIFF
--- a/MoodDetector/Controller/Service/IMoodService.cs
+++ b/MoodDetector/Controller/Service/IMoodService.cs
@@ -7,8 +7,8 @@ namespace Controller.Service
 {
     public interface IMoodService
     {
-        int AddClassMood(SessionInfo sessionInfo);
-        void AddMood(int sessionId, AddMood addMood);
+        int AddSession(SessionInfo sessionInfo);
+        void AddMood(int sessionId, MoodCollection moodCollection);
         List<Mood> GetMoodsByDate(User user, DateTime? dateTime = null);
         Mood GetLastClassMood(User user, int mask);
         void UpdateSessionMessageStatus(int classmoodId, int mask);

--- a/MoodDetector/Controller/Service/IMoodService.cs
+++ b/MoodDetector/Controller/Service/IMoodService.cs
@@ -7,7 +7,8 @@ namespace Controller.Service
 {
     public interface IMoodService
     {
-        void AddClassMood(AddMood addMood);
+        int AddClassMood(SessionInfo sessionInfo);
+        void AddMood(int sessionId, AddMood addMood);
         List<Mood> GetMoodsByDate(User user, DateTime? dateTime = null);
         Mood GetLastClassMood(User user, int mask);
         void UpdateSessionMessageStatus(int classmoodId, int mask);

--- a/MoodDetector/Controller/Service/LearningService.cs
+++ b/MoodDetector/Controller/Service/LearningService.cs
@@ -17,17 +17,17 @@ namespace Controller.Service
         public Tuple<string, int, int> GetAngerMessage()
         {
             Mood mood = _moodService.GetLastClassMood(user, 1);
-            if (mood.Anger < 0.8) return new Tuple<string, int, int>("", mood.ClassMoodId, 1);
+            if (mood.Anger < 0.8) return new Tuple<string, int, int>("", mood.SessionId, 1);
             string mess = "Anger levels are too high in your classes! You have a learning assigned";
-            return new Tuple<string, int, int>(mess, mood.ClassMoodId, 1);
+            return new Tuple<string, int, int>(mess, mood.SessionId, 1);
         }
 
         public Tuple<string, int, int> GetJoyMessage()
         {
             Mood mood = _moodService.GetLastClassMood(user, 2);
-            if (mood.Joy >= 0.8) return new Tuple<string, int, int>("", mood.ClassMoodId, 2);
+            if (mood.Joy >= 0.8) return new Tuple<string, int, int>("", mood.SessionId, 2);
             string mess = "Joy levels are too low in your classes! You have a learning assigned";
-            return new Tuple<string, int, int>(mess, mood.ClassMoodId, 2);
+            return new Tuple<string, int, int>(mess, mood.SessionId, 2);
         }
     }
 }

--- a/MoodDetector/Controller/Service/MoodService.cs
+++ b/MoodDetector/Controller/Service/MoodService.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
-using System.Diagnostics;
 
 namespace Controller.Service
 {
@@ -17,19 +16,29 @@ namespace Controller.Service
             _context = context;
         }
 
-        public void AddClassMood(AddMood addMood)
+        public int AddClassMood(SessionInfo sessionInfo)
+        {
+            var classMood = new ClassMood()
+            {
+                UserId = sessionInfo.User.Id,
+                Subject = sessionInfo.Subject,
+                Class = sessionInfo.Class,
+                DateTime = sessionInfo.DateTime,
+                Comments = sessionInfo.Comments,
+                MessageSeen = sessionInfo.MessageSeen
+            };
+
+            _context.ClassMoods.Add(classMood);
+            _context.SaveChanges();
+
+            return classMood.Id;
+        }
+
+        public void AddMood(int sessionId, AddMood addMood)
         {
             var mood = new Mood()
             {
-                ClassMood = new ClassMood()
-                {
-                    UserId = addMood.SessionInfo.User.Id,
-                    Subject = addMood.SessionInfo.Subject,
-                    Class = addMood.SessionInfo.Class,
-                    DateTime = addMood.SessionInfo.DateTime,
-                    Comments = addMood.SessionInfo.Comments,
-                    MessageSeen = addMood.SessionInfo.MessageSeen
-                },
+                ClassMoodId = sessionId,
                 Anger = addMood.MoodCollection.Anger,
                 Joy = addMood.MoodCollection.Joy,
                 Contempt = addMood.MoodCollection.Contempt,
@@ -40,9 +49,11 @@ namespace Controller.Service
                 Suprise = addMood.MoodCollection.Suprise,
                 Valence = addMood.MoodCollection.Valence,
             };
+
             _context.Moods.Add(mood);
             _context.SaveChanges();
         }
+
 
         public List<Mood> GetMoodsByDate(User user, DateTime? dateTime = null)
         {

--- a/MoodDetector/Model/Entity/AddMood.cs
+++ b/MoodDetector/Model/Entity/AddMood.cs
@@ -1,7 +1,0 @@
-﻿namespace Model.Entity
-{
-    public struct AddMood
-    {
-        public MoodCollection MoodCollection { get; set; }
-    }
-}

--- a/MoodDetector/Model/Entity/AddMood.cs
+++ b/MoodDetector/Model/Entity/AddMood.cs
@@ -3,6 +3,5 @@
     public struct AddMood
     {
         public MoodCollection MoodCollection { get; set; }
-        public SessionInfo SessionInfo { get; set; }
     }
 }

--- a/MoodDetector/Model/Model.csproj
+++ b/MoodDetector/Model/Model.csproj
@@ -76,13 +76,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ClassMood.cs">
-      <DependentUpon>MoodDetectorModel.tt</DependentUpon>
-    </Compile>
     <Compile Include="C__RefactorLog.cs">
       <DependentUpon>MoodDetectorModel.tt</DependentUpon>
     </Compile>
-    <Compile Include="Entity\AddMood.cs" />
     <Compile Include="Entity\AddUser.cs" />
     <Compile Include="Entity\MoodCollection.cs" />
     <Compile Include="Entity\SessionInfo.cs" />
@@ -106,6 +102,9 @@
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>MoodDetectorModel.edmx</DependentUpon>
+    </Compile>
+    <Compile Include="Session.cs">
+      <DependentUpon>MoodDetectorModel.tt</DependentUpon>
     </Compile>
     <Compile Include="User.cs">
       <DependentUpon>MoodDetectorModel.tt</DependentUpon>

--- a/MoodDetector/Model/Mood.cs
+++ b/MoodDetector/Model/Mood.cs
@@ -15,7 +15,7 @@ namespace Model
     public partial class Mood
     {
         public int Id { get; set; }
-        public int ClassMoodId { get; set; }
+        public int SessionId { get; set; }
         public double Anger { get; set; }
         public double Joy { get; set; }
         public double Contempt { get; set; }
@@ -26,6 +26,6 @@ namespace Model
         public double Suprise { get; set; }
         public double Valence { get; set; }
     
-        public virtual ClassMood ClassMood { get; set; }
+        public virtual Session Session { get; set; }
     }
 }

--- a/MoodDetector/Model/MoodDetectorModel.Context.cs
+++ b/MoodDetector/Model/MoodDetectorModel.Context.cs
@@ -27,11 +27,11 @@ namespace Model
             throw new UnintentionalCodeFirstException();
         }
     
-        public virtual DbSet<LoginInfo> LoginInfoes { get; set; }
-        public virtual DbSet<User> Users { get; set; }
         public virtual DbSet<C__RefactorLog> C__RefactorLog { get; set; }
-        public virtual DbSet<ClassMood> ClassMoods { get; set; }
+        public virtual DbSet<LoginInfo> LoginInfoes { get; set; }
         public virtual DbSet<Mood> Moods { get; set; }
+        public virtual DbSet<Session> Sessions { get; set; }
+        public virtual DbSet<User> Users { get; set; }
     
         public virtual int addUsers()
         {

--- a/MoodDetector/Model/MoodDetectorModel.Designer.cs
+++ b/MoodDetector/Model/MoodDetectorModel.Designer.cs
@@ -1,4 +1,4 @@
-﻿// T4 code generation is enabled for model 'C:\Users\Dilanas\source\repos\mood-detector\MoodDetector\Model\MoodDetectorModel.edmx'. 
+﻿// T4 code generation is enabled for model 'C:\Users\Dilanas\Desktop\mood-detector\MoodDetector\Model\MoodDetectorModel.edmx'. 
 // To enable legacy code generation, change the value of the 'Code Generation Strategy' designer
 // property to 'Legacy ObjectContext'. This property is available in the Properties Window when the model
 // is open in the designer.

--- a/MoodDetector/Model/MoodDetectorModel.edmx
+++ b/MoodDetector/Model/MoodDetectorModel.edmx
@@ -11,18 +11,6 @@
           </Key>
           <Property Name="OperationKey" Type="uniqueidentifier" Nullable="false" />
         </EntityType>
-        <EntityType Name="ClassMood">
-          <Key>
-            <PropertyRef Name="Id" />
-          </Key>
-          <Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
-          <Property Name="UserId" Type="int" Nullable="false" />
-          <Property Name="Subject" Type="nvarchar" MaxLength="30" Nullable="false" />
-          <Property Name="Class" Type="nvarchar" MaxLength="30" Nullable="false" />
-          <Property Name="DateTime" Type="datetime" Nullable="false" />
-          <Property Name="Comments" Type="text" Nullable="false" />
-		  <Property Name="MessageSeen" Type="int" Nullable="false" />
-        </EntityType>
         <EntityType Name="LoginInfo">
           <Key>
             <PropertyRef Name="Id" />
@@ -38,7 +26,7 @@
             <PropertyRef Name="Id" />
           </Key>
           <Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
-          <Property Name="ClassMoodId" Type="int" Nullable="false" />
+          <Property Name="SessionId" Type="int" Nullable="false" />
           <Property Name="Anger" Type="float" Nullable="false" />
           <Property Name="Joy" Type="float" Nullable="false" />
           <Property Name="Contempt" Type="float" Nullable="false" />
@@ -49,6 +37,18 @@
           <Property Name="Suprise" Type="float" Nullable="false" />
           <Property Name="Valence" Type="float" Nullable="false" />
         </EntityType>
+        <EntityType Name="Session">
+          <Key>
+            <PropertyRef Name="Id" />
+          </Key>
+          <Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
+          <Property Name="UserId" Type="int" Nullable="false" />
+          <Property Name="Subject" Type="nvarchar" MaxLength="30" Nullable="false" />
+          <Property Name="Class" Type="nvarchar" MaxLength="30" Nullable="false" />
+          <Property Name="DateTime" Type="datetime" Nullable="false" />
+          <Property Name="Comments" Type="text" Nullable="false" />
+          <Property Name="MessageSeen" Type="int" Nullable="false" />
+        </EntityType>
         <EntityType Name="User">
           <Key>
             <PropertyRef Name="Id" />
@@ -58,18 +58,6 @@
           <Property Name="Lastname" Type="nvarchar" MaxLength="50" Nullable="false" />
           <Property Name="AccessRights" Type="nvarchar" MaxLength="50" Nullable="false" />
         </EntityType>
-        <Association Name="FK_ClassMood_User">
-          <End Role="User" Type="Self.User" Multiplicity="1" />
-          <End Role="ClassMood" Type="Self.ClassMood" Multiplicity="*" />
-          <ReferentialConstraint>
-            <Principal Role="User">
-              <PropertyRef Name="Id" />
-            </Principal>
-            <Dependent Role="ClassMood">
-              <PropertyRef Name="UserId" />
-            </Dependent>
-          </ReferentialConstraint>
-        </Association>
         <Association Name="FK_LoginInfo_User">
           <End Role="User" Type="Self.User" Multiplicity="1" />
           <End Role="LoginInfo" Type="Self.LoginInfo" Multiplicity="*" />
@@ -82,94 +70,72 @@
             </Dependent>
           </ReferentialConstraint>
         </Association>
-        <Association Name="FK_Mood_ClassMood">
-          <End Role="ClassMood" Type="Self.ClassMood" Multiplicity="1" />
+        <Association Name="FK_Mood_Session">
+          <End Role="Session" Type="Self.Session" Multiplicity="1" />
           <End Role="Mood" Type="Self.Mood" Multiplicity="*" />
           <ReferentialConstraint>
-            <Principal Role="ClassMood">
+            <Principal Role="Session">
               <PropertyRef Name="Id" />
             </Principal>
             <Dependent Role="Mood">
-              <PropertyRef Name="ClassMoodId" />
+              <PropertyRef Name="SessionId" />
+            </Dependent>
+          </ReferentialConstraint>
+        </Association>
+        <Association Name="FK_Session_User">
+          <End Role="User" Type="Self.User" Multiplicity="1" />
+          <End Role="Session" Type="Self.Session" Multiplicity="*" />
+          <ReferentialConstraint>
+            <Principal Role="User">
+              <PropertyRef Name="Id" />
+            </Principal>
+            <Dependent Role="Session">
+              <PropertyRef Name="UserId" />
             </Dependent>
           </ReferentialConstraint>
         </Association>
         <Function Name="addUsers" Aggregate="false" BuiltIn="false" NiladicFunction="false" IsComposable="false" ParameterTypeSemantics="AllowImplicitConversion" Schema="dbo" />
         <EntityContainer Name="MoodDetectorDBModelStoreContainer">
           <EntitySet Name="__RefactorLog" EntityType="Self.__RefactorLog" Schema="dbo" store:Type="Tables" />
-          <EntitySet Name="ClassMood" EntityType="Self.ClassMood" Schema="dbo" store:Type="Tables" />
           <EntitySet Name="LoginInfo" EntityType="Self.LoginInfo" Schema="dbo" store:Type="Tables" />
           <EntitySet Name="Mood" EntityType="Self.Mood" Schema="dbo" store:Type="Tables" />
+          <EntitySet Name="Session" EntityType="Self.Session" Schema="dbo" store:Type="Tables" />
           <EntitySet Name="User" EntityType="Self.User" Schema="dbo" store:Type="Tables" />
-          <AssociationSet Name="FK_ClassMood_User" Association="Self.FK_ClassMood_User">
-            <End Role="User" EntitySet="User" />
-            <End Role="ClassMood" EntitySet="ClassMood" />
-          </AssociationSet>
           <AssociationSet Name="FK_LoginInfo_User" Association="Self.FK_LoginInfo_User">
             <End Role="User" EntitySet="User" />
             <End Role="LoginInfo" EntitySet="LoginInfo" />
           </AssociationSet>
-          <AssociationSet Name="FK_Mood_ClassMood" Association="Self.FK_Mood_ClassMood">
-            <End Role="ClassMood" EntitySet="ClassMood" />
+          <AssociationSet Name="FK_Mood_Session" Association="Self.FK_Mood_Session">
+            <End Role="Session" EntitySet="Session" />
             <End Role="Mood" EntitySet="Mood" />
+          </AssociationSet>
+          <AssociationSet Name="FK_Session_User" Association="Self.FK_Session_User">
+            <End Role="User" EntitySet="User" />
+            <End Role="Session" EntitySet="Session" />
           </AssociationSet>
         </EntityContainer>
       </Schema></edmx:StorageModels>
     <!-- CSDL content -->
     <edmx:ConceptualModels>
       <Schema Namespace="MoodDetectorDBModel" Alias="Self" annotation:UseStrongSpatialTypes="false" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" xmlns:customannotation="http://schemas.microsoft.com/ado/2013/11/edm/customannotation" xmlns="http://schemas.microsoft.com/ado/2009/11/edm">
-        <EntityType Name="LoginInfo">
-          <Key>
-            <PropertyRef Name="Id" />
-          </Key>
-          <Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
-          <Property Name="UserId" Type="Int32" Nullable="false" />
-          <Property Name="Username" Type="String" MaxLength="50" FixedLength="false" Unicode="true" Nullable="false" />
-          <Property Name="Password" Type="String" MaxLength="50" FixedLength="false" Unicode="true" Nullable="false" />
-          <Property Name="Email" Type="String" MaxLength="50" FixedLength="false" Unicode="true" Nullable="false" />
-          <NavigationProperty Name="User" Relationship="Self.FK_LoginInfo_User" FromRole="LoginInfo" ToRole="User" />
-        </EntityType>
-        <EntityType Name="User">
-          <Key>
-            <PropertyRef Name="Id" />
-          </Key>
-          <Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
-          <Property Name="Firstname" Type="String" MaxLength="50" FixedLength="false" Unicode="true" Nullable="false" />
-          <Property Name="Lastname" Type="String" MaxLength="50" FixedLength="false" Unicode="true" Nullable="false" />
-          <Property Name="AccessRights" Type="String" MaxLength="50" FixedLength="false" Unicode="true" Nullable="false" />
-          <NavigationProperty Name="LoginInfoes" Relationship="Self.FK_LoginInfo_User" FromRole="User" ToRole="LoginInfo" />
-          <NavigationProperty Name="ClassMoods" Relationship="MoodDetectorDBModel.FK_ClassMood_User" FromRole="User" ToRole="ClassMood" />
-        </EntityType>
-        <Association Name="FK_LoginInfo_User">
-          <End Role="User" Type="Self.User" Multiplicity="1" />
-          <End Role="LoginInfo" Type="Self.LoginInfo" Multiplicity="*" />
-          <ReferentialConstraint>
-            <Principal Role="User">
-              <PropertyRef Name="Id" />
-            </Principal>
-            <Dependent Role="LoginInfo">
-              <PropertyRef Name="UserId" />
-            </Dependent>
-          </ReferentialConstraint>
-        </Association>
         <EntityContainer Name="MoodDetectorDBEntities" annotation:LazyLoadingEnabled="true">
-          <EntitySet Name="LoginInfoes" EntityType="Self.LoginInfo" />
-          <EntitySet Name="Users" EntityType="Self.User" />
-          <AssociationSet Name="FK_LoginInfo_User" Association="Self.FK_LoginInfo_User">
+          <FunctionImport Name="addUsers" />
+          <EntitySet Name="C__RefactorLog" EntityType="MoodDetectorDBModel.C__RefactorLog" />
+          <EntitySet Name="LoginInfoes" EntityType="MoodDetectorDBModel.LoginInfo" />
+          <EntitySet Name="Moods" EntityType="MoodDetectorDBModel.Mood" />
+          <EntitySet Name="Sessions" EntityType="MoodDetectorDBModel.Session" />
+          <EntitySet Name="Users" EntityType="MoodDetectorDBModel.User" />
+          <AssociationSet Name="FK_LoginInfo_User" Association="MoodDetectorDBModel.FK_LoginInfo_User">
             <End Role="User" EntitySet="Users" />
             <End Role="LoginInfo" EntitySet="LoginInfoes" />
           </AssociationSet>
-          <FunctionImport Name="addUsers" />
-          <EntitySet Name="C__RefactorLog" EntityType="MoodDetectorDBModel.C__RefactorLog" />
-          <EntitySet Name="ClassMoods" EntityType="MoodDetectorDBModel.ClassMood" />
-          <EntitySet Name="Moods" EntityType="MoodDetectorDBModel.Mood" />
-          <AssociationSet Name="FK_ClassMood_User" Association="MoodDetectorDBModel.FK_ClassMood_User">
-            <End Role="User" EntitySet="Users" />
-            <End Role="ClassMood" EntitySet="ClassMoods" />
-          </AssociationSet>
-          <AssociationSet Name="FK_Mood_ClassMood" Association="MoodDetectorDBModel.FK_Mood_ClassMood">
-            <End Role="ClassMood" EntitySet="ClassMoods" />
+          <AssociationSet Name="FK_Mood_Session" Association="MoodDetectorDBModel.FK_Mood_Session">
+            <End Role="Session" EntitySet="Sessions" />
             <End Role="Mood" EntitySet="Moods" />
+          </AssociationSet>
+          <AssociationSet Name="FK_Session_User" Association="MoodDetectorDBModel.FK_Session_User">
+            <End Role="User" EntitySet="Users" />
+            <End Role="Session" EntitySet="Sessions" />
           </AssociationSet>
         </EntityContainer>
         <EntityType Name="C__RefactorLog">
@@ -178,26 +144,23 @@
           </Key>
           <Property Name="OperationKey" Type="Guid" Nullable="false" />
         </EntityType>
-        <EntityType Name="ClassMood">
+        <EntityType Name="LoginInfo">
           <Key>
             <PropertyRef Name="Id" />
           </Key>
           <Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
           <Property Name="UserId" Type="Int32" Nullable="false" />
-          <Property Name="Subject" Type="String" Nullable="false" MaxLength="30" FixedLength="false" Unicode="true" />
-          <Property Name="Class" Type="String" Nullable="false" MaxLength="30" FixedLength="false" Unicode="true" />
-          <Property Name="DateTime" Type="DateTime" Nullable="false" Precision="3" />
-          <Property Name="Comments" Type="String" Nullable="false" MaxLength="Max" FixedLength="false" Unicode="false" />
-		  <Property Name="MessageSeen" Type="Int32" Nullable="false" />
-          <NavigationProperty Name="User" Relationship="MoodDetectorDBModel.FK_ClassMood_User" FromRole="ClassMood" ToRole="User" />
-          <NavigationProperty Name="Moods" Relationship="MoodDetectorDBModel.FK_Mood_ClassMood" FromRole="ClassMood" ToRole="Mood" />
+          <Property Name="Username" Type="String" Nullable="false" MaxLength="50" FixedLength="false" Unicode="true" />
+          <Property Name="Password" Type="String" Nullable="false" MaxLength="50" FixedLength="false" Unicode="true" />
+          <Property Name="Email" Type="String" Nullable="false" MaxLength="50" FixedLength="false" Unicode="true" />
+          <NavigationProperty Name="User" Relationship="MoodDetectorDBModel.FK_LoginInfo_User" FromRole="LoginInfo" ToRole="User" />
         </EntityType>
         <EntityType Name="Mood">
           <Key>
             <PropertyRef Name="Id" />
           </Key>
           <Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
-          <Property Name="ClassMoodId" Type="Int32" Nullable="false" />
+          <Property Name="SessionId" Type="Int32" Nullable="false" />
           <Property Name="Anger" Type="Double" Nullable="false" />
           <Property Name="Joy" Type="Double" Nullable="false" />
           <Property Name="Contempt" Type="Double" Nullable="false" />
@@ -207,29 +170,66 @@
           <Property Name="Sadness" Type="Double" Nullable="false" />
           <Property Name="Suprise" Type="Double" Nullable="false" />
           <Property Name="Valence" Type="Double" Nullable="false" />
-          <NavigationProperty Name="ClassMood" Relationship="MoodDetectorDBModel.FK_Mood_ClassMood" FromRole="Mood" ToRole="ClassMood" />
+          <NavigationProperty Name="Session" Relationship="MoodDetectorDBModel.FK_Mood_Session" FromRole="Mood" ToRole="Session" />
         </EntityType>
-        <Association Name="FK_ClassMood_User">
+        <EntityType Name="Session">
+          <Key>
+            <PropertyRef Name="Id" />
+          </Key>
+          <Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
+          <Property Name="UserId" Type="Int32" Nullable="false" />
+          <Property Name="Subject" Type="String" Nullable="false" MaxLength="30" FixedLength="false" Unicode="true" />
+          <Property Name="Class" Type="String" Nullable="false" MaxLength="30" FixedLength="false" Unicode="true" />
+          <Property Name="DateTime" Type="DateTime" Nullable="false" Precision="3" />
+          <Property Name="Comments" Type="String" Nullable="false" MaxLength="Max" FixedLength="false" Unicode="false" />
+          <Property Name="MessageSeen" Type="Int32" Nullable="false" />
+          <NavigationProperty Name="Moods" Relationship="MoodDetectorDBModel.FK_Mood_Session" FromRole="Session" ToRole="Mood" />
+          <NavigationProperty Name="User" Relationship="MoodDetectorDBModel.FK_Session_User" FromRole="Session" ToRole="User" />
+        </EntityType>
+        <EntityType Name="User">
+          <Key>
+            <PropertyRef Name="Id" />
+          </Key>
+          <Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
+          <Property Name="Firstname" Type="String" Nullable="false" MaxLength="50" FixedLength="false" Unicode="true" />
+          <Property Name="Lastname" Type="String" Nullable="false" MaxLength="50" FixedLength="false" Unicode="true" />
+          <Property Name="AccessRights" Type="String" Nullable="false" MaxLength="50" FixedLength="false" Unicode="true" />
+          <NavigationProperty Name="LoginInfoes" Relationship="MoodDetectorDBModel.FK_LoginInfo_User" FromRole="User" ToRole="LoginInfo" />
+          <NavigationProperty Name="Sessions" Relationship="MoodDetectorDBModel.FK_Session_User" FromRole="User" ToRole="Session" />
+        </EntityType>
+        <Association Name="FK_LoginInfo_User">
           <End Type="MoodDetectorDBModel.User" Role="User" Multiplicity="1" />
-          <End Type="MoodDetectorDBModel.ClassMood" Role="ClassMood" Multiplicity="*" />
+          <End Type="MoodDetectorDBModel.LoginInfo" Role="LoginInfo" Multiplicity="*" />
           <ReferentialConstraint>
             <Principal Role="User">
               <PropertyRef Name="Id" />
             </Principal>
-            <Dependent Role="ClassMood">
+            <Dependent Role="LoginInfo">
               <PropertyRef Name="UserId" />
             </Dependent>
           </ReferentialConstraint>
         </Association>
-        <Association Name="FK_Mood_ClassMood">
-          <End Type="MoodDetectorDBModel.ClassMood" Role="ClassMood" Multiplicity="1" />
+        <Association Name="FK_Mood_Session">
+          <End Type="MoodDetectorDBModel.Session" Role="Session" Multiplicity="1" />
           <End Type="MoodDetectorDBModel.Mood" Role="Mood" Multiplicity="*" />
           <ReferentialConstraint>
-            <Principal Role="ClassMood">
+            <Principal Role="Session">
               <PropertyRef Name="Id" />
             </Principal>
             <Dependent Role="Mood">
-              <PropertyRef Name="ClassMoodId" />
+              <PropertyRef Name="SessionId" />
+            </Dependent>
+          </ReferentialConstraint>
+        </Association>
+        <Association Name="FK_Session_User">
+          <End Type="MoodDetectorDBModel.User" Role="User" Multiplicity="1" />
+          <End Type="MoodDetectorDBModel.Session" Role="Session" Multiplicity="*" />
+          <ReferentialConstraint>
+            <Principal Role="User">
+              <PropertyRef Name="Id" />
+            </Principal>
+            <Dependent Role="Session">
+              <PropertyRef Name="UserId" />
             </Dependent>
           </ReferentialConstraint>
         </Association>
@@ -239,27 +239,6 @@
     <edmx:Mappings>
       <Mapping Space="C-S" xmlns="http://schemas.microsoft.com/ado/2009/11/mapping/cs">
         <EntityContainerMapping StorageEntityContainer="MoodDetectorDBModelStoreContainer" CdmEntityContainer="MoodDetectorDBEntities">
-          <EntitySetMapping Name="LoginInfoes">
-            <EntityTypeMapping TypeName="MoodDetectorDBModel.LoginInfo">
-              <MappingFragment StoreEntitySet="LoginInfo">
-                <ScalarProperty Name="Id" ColumnName="Id" />
-                <ScalarProperty Name="UserId" ColumnName="UserId" />
-                <ScalarProperty Name="Username" ColumnName="Username" />
-                <ScalarProperty Name="Password" ColumnName="Password" />
-                <ScalarProperty Name="Email" ColumnName="Email" />
-              </MappingFragment>
-            </EntityTypeMapping>
-          </EntitySetMapping>
-          <EntitySetMapping Name="Users">
-            <EntityTypeMapping TypeName="MoodDetectorDBModel.User">
-              <MappingFragment StoreEntitySet="User">
-                <ScalarProperty Name="Id" ColumnName="Id" />
-                <ScalarProperty Name="Firstname" ColumnName="Firstname" />
-                <ScalarProperty Name="Lastname" ColumnName="Lastname" />
-                <ScalarProperty Name="AccessRights" ColumnName="AccessRights" />
-              </MappingFragment>
-            </EntityTypeMapping>
-          </EntitySetMapping>
           <FunctionImportMapping FunctionImportName="addUsers" FunctionName="MoodDetectorDBModel.Store.addUsers" />
           <EntitySetMapping Name="C__RefactorLog">
             <EntityTypeMapping TypeName="MoodDetectorDBModel.C__RefactorLog">
@@ -268,14 +247,12 @@
               </MappingFragment>
             </EntityTypeMapping>
           </EntitySetMapping>
-          <EntitySetMapping Name="ClassMoods">
-            <EntityTypeMapping TypeName="MoodDetectorDBModel.ClassMood">
-              <MappingFragment StoreEntitySet="ClassMood">
-				<ScalarProperty Name="MessageSeen" ColumnName="MessageSeen" />
-                <ScalarProperty Name="Comments" ColumnName="Comments" />
-                <ScalarProperty Name="DateTime" ColumnName="DateTime" />
-                <ScalarProperty Name="Class" ColumnName="Class" />
-                <ScalarProperty Name="Subject" ColumnName="Subject" />
+          <EntitySetMapping Name="LoginInfoes">
+            <EntityTypeMapping TypeName="MoodDetectorDBModel.LoginInfo">
+              <MappingFragment StoreEntitySet="LoginInfo">
+                <ScalarProperty Name="Email" ColumnName="Email" />
+                <ScalarProperty Name="Password" ColumnName="Password" />
+                <ScalarProperty Name="Username" ColumnName="Username" />
                 <ScalarProperty Name="UserId" ColumnName="UserId" />
                 <ScalarProperty Name="Id" ColumnName="Id" />
               </MappingFragment>
@@ -293,7 +270,30 @@
                 <ScalarProperty Name="Contempt" ColumnName="Contempt" />
                 <ScalarProperty Name="Joy" ColumnName="Joy" />
                 <ScalarProperty Name="Anger" ColumnName="Anger" />
-                <ScalarProperty Name="ClassMoodId" ColumnName="ClassMoodId" />
+                <ScalarProperty Name="SessionId" ColumnName="SessionId" />
+                <ScalarProperty Name="Id" ColumnName="Id" />
+              </MappingFragment>
+            </EntityTypeMapping>
+          </EntitySetMapping>
+          <EntitySetMapping Name="Sessions">
+            <EntityTypeMapping TypeName="MoodDetectorDBModel.Session">
+              <MappingFragment StoreEntitySet="Session">
+                <ScalarProperty Name="MessageSeen" ColumnName="MessageSeen" />
+                <ScalarProperty Name="Comments" ColumnName="Comments" />
+                <ScalarProperty Name="DateTime" ColumnName="DateTime" />
+                <ScalarProperty Name="Class" ColumnName="Class" />
+                <ScalarProperty Name="Subject" ColumnName="Subject" />
+                <ScalarProperty Name="UserId" ColumnName="UserId" />
+                <ScalarProperty Name="Id" ColumnName="Id" />
+              </MappingFragment>
+            </EntityTypeMapping>
+          </EntitySetMapping>
+          <EntitySetMapping Name="Users">
+            <EntityTypeMapping TypeName="MoodDetectorDBModel.User">
+              <MappingFragment StoreEntitySet="User">
+                <ScalarProperty Name="AccessRights" ColumnName="AccessRights" />
+                <ScalarProperty Name="Lastname" ColumnName="Lastname" />
+                <ScalarProperty Name="Firstname" ColumnName="Firstname" />
                 <ScalarProperty Name="Id" ColumnName="Id" />
               </MappingFragment>
             </EntityTypeMapping>

--- a/MoodDetector/Model/MoodDetectorModel.edmx.diagram
+++ b/MoodDetector/Model/MoodDetectorModel.edmx.diagram
@@ -5,15 +5,15 @@
     <!-- Diagram content (shape and connector positions) -->
     <edmx:Diagrams>
       <Diagram DiagramId="dcfd1cf7207443a4b94a42ca784bfc24" Name="Diagram1">
-        <EntityTypeShape EntityType="MoodDetectorDBModel.LoginInfo" Width="1.5" PointX="3" PointY="4" IsExpanded="true" />
-        <EntityTypeShape EntityType="MoodDetectorDBModel.User" Width="1.5" PointX="0.75" PointY="2.5" IsExpanded="true" />
-        <AssociationConnector Association="MoodDetectorDBModel.FK_LoginInfo_User" ManuallyRouted="false" />
-        <EntityTypeShape EntityType="MoodDetectorDBModel.C__RefactorLog" Width="1.5" PointX="5.375" PointY="5.75" />
-        <EntityTypeShape EntityType="MoodDetectorDBModel.ClassMood" Width="1.5" PointX="3" PointY="0.75" />
-        <EntityTypeShape EntityType="MoodDetectorDBModel.Mood" Width="1.5" PointX="5.25" PointY="9.125" />
-        <AssociationConnector Association="MoodDetectorDBModel.FK_ClassMood_User" />
-        <AssociationConnector Association="MoodDetectorDBModel.FK_Mood_ClassMood" />
-        </Diagram>
+        <EntityTypeShape EntityType="MoodDetectorDBModel.C__RefactorLog" Width="1.5" PointX="5.75" PointY="0.75" />
+        <EntityTypeShape EntityType="MoodDetectorDBModel.LoginInfo" Width="1.5" PointX="3" PointY="1.125" />
+        <EntityTypeShape EntityType="MoodDetectorDBModel.Mood" Width="1.5" PointX="5.25" PointY="4" />
+        <EntityTypeShape EntityType="MoodDetectorDBModel.Session" Width="1.5" PointX="3" PointY="4.375" />
+        <EntityTypeShape EntityType="MoodDetectorDBModel.User" Width="1.5" PointX="0.75" PointY="3.125" />
+        <AssociationConnector Association="MoodDetectorDBModel.FK_LoginInfo_User" />
+        <AssociationConnector Association="MoodDetectorDBModel.FK_Mood_Session" />
+        <AssociationConnector Association="MoodDetectorDBModel.FK_Session_User" />
+      </Diagram>
     </edmx:Diagrams>
   </edmx:Designer>
 </edmx:Edmx>

--- a/MoodDetector/Model/Session.cs
+++ b/MoodDetector/Model/Session.cs
@@ -12,10 +12,10 @@ namespace Model
     using System;
     using System.Collections.Generic;
     
-    public partial class ClassMood
+    public partial class Session
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
-        public ClassMood()
+        public Session()
         {
             this.Moods = new HashSet<Mood>();
         }
@@ -28,8 +28,8 @@ namespace Model
         public string Comments { get; set; }
         public int MessageSeen { get; set; }
     
-        public virtual User User { get; set; }
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public virtual ICollection<Mood> Moods { get; set; }
+        public virtual User User { get; set; }
     }
 }

--- a/MoodDetector/Model/User.cs
+++ b/MoodDetector/Model/User.cs
@@ -18,7 +18,7 @@ namespace Model
         public User()
         {
             this.LoginInfoes = new HashSet<LoginInfo>();
-            this.ClassMoods = new HashSet<ClassMood>();
+            this.Sessions = new HashSet<Session>();
         }
     
         public int Id { get; set; }
@@ -29,6 +29,6 @@ namespace Model
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public virtual ICollection<LoginInfo> LoginInfoes { get; set; }
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
-        public virtual ICollection<ClassMood> ClassMoods { get; set; }
+        public virtual ICollection<Session> Sessions { get; set; }
     }
 }

--- a/MoodDetector/SQLServer/SQLServer.sqlproj
+++ b/MoodDetector/SQLServer/SQLServer.sqlproj
@@ -91,7 +91,7 @@
     <Build Include="dbo\Tables\User.sql">
       <CopyToOutputDirectory>DoNotCopy</CopyToOutputDirectory>
     </Build>
-    <Build Include="dbo\Tables\ClassMood.sql">
+    <Build Include="dbo\Tables\Session.sql">
       <CopyToOutputDirectory>DoNotCopy</CopyToOutputDirectory>
     </Build>
     <Build Include="dbo\Tables\LoginInfo.sql">

--- a/MoodDetector/SQLServer/dbo/Tables/Mood.sql
+++ b/MoodDetector/SQLServer/dbo/Tables/Mood.sql
@@ -1,7 +1,7 @@
 ﻿CREATE TABLE [dbo].[Mood]
 (
 	[Id] INT NOT NULL PRIMARY KEY IDENTITY, 
-    [ClassMoodId] INT NOT NULL, 
+    [SessionId] INT NOT NULL, 
     [Anger] FLOAT NOT NULL, 
     [Joy] FLOAT NOT NULL, 
 	[Contempt] FLOAT NOT NULL, 
@@ -11,5 +11,5 @@
 	[Sadness] FLOAT NOT NULL, 
 	[Suprise] FLOAT NOT NULL, 
 	[Valence] FLOAT NOT NULL, 
-    CONSTRAINT [FK_Mood_ClassMood] FOREIGN KEY ([ClassMoodId]) REFERENCES [ClassMood]([Id])
+    CONSTRAINT [FK_Mood_Session] FOREIGN KEY ([SessionId]) REFERENCES [Session]([Id])
 )

--- a/MoodDetector/SQLServer/dbo/Tables/Session.sql
+++ b/MoodDetector/SQLServer/dbo/Tables/Session.sql
@@ -1,4 +1,4 @@
-﻿CREATE TABLE [dbo].[ClassMood]
+﻿CREATE TABLE [dbo].[Session]
 (
 	[Id] INT NOT NULL PRIMARY KEY IDENTITY, 
     [UserId] INT NOT NULL, 
@@ -7,5 +7,5 @@
 	[DateTime] DATETIME Not NULL, 
     [Comments] TEXT NOT NULL, 
     [MessageSeen] INT NOT NULL , 
-    CONSTRAINT [FK_ClassMood_User] FOREIGN KEY ([UserId]) REFERENCES [User]([Id]), 
+    CONSTRAINT [FK_Session_User] FOREIGN KEY ([UserId]) REFERENCES [User]([Id]), 
 )

--- a/MoodDetector/UnitTest/Service/MoodServiceTest/MoodServiceTest.cs
+++ b/MoodDetector/UnitTest/Service/MoodServiceTest/MoodServiceTest.cs
@@ -13,7 +13,23 @@ namespace UnitTest.Service.MoodServiceTest
     public class MoodServiceTest
     {
         [Fact]
-        public void TestAddClassMood()
+        public void TestAddSession()
+        {
+            var mockSet = new Mock<DbSet<Session>>();
+
+            var mockContext = new Mock<MoodDetectorDBEntities>();
+            mockContext.Setup(m => m.Sessions).Returns(mockSet.Object);
+
+            var service = new MoodService(mockContext.Object);
+            SessionInfo sessionInfo = CreateSessionInfo();
+            service.AddSession(sessionInfo);
+
+            mockSet.Verify(m => m.Add(It.IsAny<Session>()), Times.Once());
+            mockContext.Verify(m => m.SaveChanges(), Times.Once());
+        }
+
+        [Fact]
+        public void TestAddMood()
         {
             var mockSet = new Mock<DbSet<Mood>>();
 
@@ -21,8 +37,8 @@ namespace UnitTest.Service.MoodServiceTest
             mockContext.Setup(m => m.Moods).Returns(mockSet.Object);
 
             var service = new MoodService(mockContext.Object);
-            SessionInfo sessionInfo = CreateSessionInfo();
-            service.AddClassMood(sessionInfo);
+            MoodCollection moodCollection = CreateMoodCollection();
+            service.AddMood(1, moodCollection);
 
             mockSet.Verify(m => m.Add(It.IsAny<Mood>()), Times.Once());
             mockContext.Verify(m => m.SaveChanges(), Times.Once());
@@ -33,9 +49,9 @@ namespace UnitTest.Service.MoodServiceTest
         {
             var moodData = new List<Mood>
             {
-                new Mood { Id = 1, ClassMoodId = 1, Joy = 100 },
-                new Mood { Id = 2, ClassMoodId = 2, Joy = 100 },
-                new Mood { Id = 3, ClassMoodId = 2, Joy = 100 },
+                new Mood { Id = 1, SessionId = 1, Joy = 100 },
+                new Mood { Id = 2, SessionId = 2, Joy = 100 },
+                new Mood { Id = 3, SessionId = 2, Joy = 100 },
             }.AsQueryable();
 
             var moodMockSet = new Mock<DbSet<Mood>>();
@@ -44,22 +60,22 @@ namespace UnitTest.Service.MoodServiceTest
             moodMockSet.As<IQueryable<Mood>>().Setup(m => m.ElementType).Returns(moodData.ElementType);
             moodMockSet.As<IQueryable<Mood>>().Setup(m => m.GetEnumerator()).Returns(moodData.GetEnumerator());
 
-            var classMoodData = new List<ClassMood>
+            var sessionData = new List<Session>
             {
-                new ClassMood { Id = 1, UserId = 1, DateTime = new DateTime(2019, 10, 13) },
-                new ClassMood { Id = 2, UserId = 1, DateTime = new DateTime(2019, 10, 11) },
+                new Session { Id = 1, UserId = 1, DateTime = new DateTime(2019, 10, 13) },
+                new Session { Id = 2, UserId = 1, DateTime = new DateTime(2019, 10, 11) },
             }.AsQueryable();
 
-            var classMoodMockSet = new Mock<DbSet<ClassMood>>();
-            classMoodMockSet.As<IQueryable<ClassMood>>().Setup(m => m.Provider).Returns(classMoodData.Provider);
-            classMoodMockSet.As<IQueryable<ClassMood>>().Setup(m => m.Expression).Returns(classMoodData.Expression);
-            classMoodMockSet.As<IQueryable<ClassMood>>().Setup(m => m.ElementType).Returns(classMoodData.ElementType);
-            classMoodMockSet.As<IQueryable<ClassMood>>().Setup(m => m.GetEnumerator()).Returns(classMoodData.GetEnumerator());
+            var sessionMockSet = new Mock<DbSet<Session>>();
+            sessionMockSet.As<IQueryable<Session>>().Setup(m => m.Provider).Returns(sessionData.Provider);
+            sessionMockSet.As<IQueryable<Session>>().Setup(m => m.Expression).Returns(sessionData.Expression);
+            sessionMockSet.As<IQueryable<Session>>().Setup(m => m.ElementType).Returns(sessionData.ElementType);
+            sessionMockSet.As<IQueryable<Session>>().Setup(m => m.GetEnumerator()).Returns(sessionData.GetEnumerator());
 
 
             var mockContext = new Mock<MoodDetectorDBEntities>();
             mockContext.Setup(c => c.Moods).Returns(moodMockSet.Object);
-            mockContext.Setup(c => c.ClassMoods).Returns(classMoodMockSet.Object);
+            mockContext.Setup(c => c.Sessions).Returns(sessionMockSet.Object);
 
             var service = new MoodService(mockContext.Object);
 
@@ -76,7 +92,7 @@ namespace UnitTest.Service.MoodServiceTest
             Assert.NotNull(moods);
             Assert.Equal(1, moods[0].Id);
             Assert.Equal(100, moods[0].Joy);
-            Assert.Equal(1, moods[0].ClassMoodId);
+            Assert.Equal(1, moods[0].SessionId);
 
             moods = service.GetMoodsByDate(GetSampleUser(1, "James", "Smith", "Teacher"), new DateTime(2019, 10, 11));
 
@@ -116,6 +132,24 @@ namespace UnitTest.Service.MoodServiceTest
             return sessionInfo;
         }
 
+        private MoodCollection CreateMoodCollection()
+        {
+            MoodCollection moodCollection = new MoodCollection
+            {
+                Anger = 100,
+                Contempt = 100,
+                Disgust = 100,
+                Engagement = 100,
+                Fear = 100,
+                Joy = 100,
+                Sadness = 100,
+                Suprise = 100,
+                Valence = 100,
+            };
+
+            return moodCollection;
+        }
+
         private User GetSampleUser(int id, string firstname, string lastname, string accessRights)
         {
             User user = new User()
@@ -136,7 +170,7 @@ namespace UnitTest.Service.MoodServiceTest
                 new Mood()
                 {
                     Id = 1,
-                    ClassMoodId = 1,
+                    SessionId = 1,
                     Anger = 100,
                     Contempt = 100,
                     Disgust = 100,
@@ -150,7 +184,7 @@ namespace UnitTest.Service.MoodServiceTest
                 new Mood()
                 {
                     Id = 2,
-                    ClassMoodId = 1,
+                    SessionId = 1,
                     Anger = 0,
                     Contempt = 0,
                     Disgust = 0,

--- a/MoodDetector/UnitTest/Service/MoodServiceTest/MoodServiceTest.cs
+++ b/MoodDetector/UnitTest/Service/MoodServiceTest/MoodServiceTest.cs
@@ -21,8 +21,8 @@ namespace UnitTest.Service.MoodServiceTest
             mockContext.Setup(m => m.Moods).Returns(mockSet.Object);
 
             var service = new MoodService(mockContext.Object);
-            AddMood mood = CreateAddMood();
-            service.AddClassMood(mood);
+            SessionInfo sessionInfo = CreateSessionInfo();
+            service.AddClassMood(sessionInfo);
 
             mockSet.Verify(m => m.Add(It.IsAny<Mood>()), Times.Once());
             mockContext.Verify(m => m.SaveChanges(), Times.Once());
@@ -101,7 +101,7 @@ namespace UnitTest.Service.MoodServiceTest
             Assert.Equal(50, moodCollection.Joy);
         }
 
-        private AddMood CreateAddMood()
+        private SessionInfo CreateSessionInfo()
         {
             DateTime dateTime = new DateTime(2019, 10, 13);
             SessionInfo sessionInfo = new SessionInfo()
@@ -112,25 +112,8 @@ namespace UnitTest.Service.MoodServiceTest
                 Comments = "Test comment",
                 DateTime = dateTime,
             };
-            MoodCollection moodCollection = new MoodCollection()
-            {
-                Anger = 100,
-                Contempt = 100,
-                Disgust = 100,
-                Engagement = 100,
-                Fear = 100,
-                Joy = 100,
-                Sadness = 100,
-                Suprise = 100,
-                Valence = 100,
-            };
-            AddMood addMood = new AddMood()
-            {
-                MoodCollection = moodCollection,
-                SessionInfo = sessionInfo,
-            };
 
-            return addMood;
+            return sessionInfo;
         }
 
         private User GetSampleUser(int id, string firstname, string lastname, string accessRights)

--- a/MoodDetector/WindowsFormsUI/SessionForm.cs
+++ b/MoodDetector/WindowsFormsUI/SessionForm.cs
@@ -8,15 +8,15 @@ namespace WindowsFormsUI
 {
     public partial class SessionForm : Form
     {
-        private SessionInfo sessionInfo;
+        private int sessionId;
         private IMoodService _moodService;
         private AffectivaService _affectivaService;
         private UserForm userForm;
 
-        public SessionForm(SessionInfo sessionInfo, IMoodService moodService, UserForm userForm)
+        public SessionForm(int sessionId, IMoodService moodService, UserForm userForm)
         {
             this.userForm = userForm;
-            this.sessionInfo = sessionInfo;
+            this.sessionId = sessionId;
             _moodService = moodService;
             _affectivaService = new AffectivaService();
             _affectivaService.StartDetector();
@@ -40,10 +40,9 @@ namespace WindowsFormsUI
                     AddMood addMood = new AddMood
                     {
                         MoodCollection = _affectivaService.GetMoodCollection(),
-                        SessionInfo = this.sessionInfo
                     };
 
-                    _moodService.AddClassMood(addMood);
+                    _moodService.AddMood(sessionId, addMood);
                 }
             }
             MessageBox.Show("Photo uploaded successfully!");

--- a/MoodDetector/WindowsFormsUI/SessionForm.cs
+++ b/MoodDetector/WindowsFormsUI/SessionForm.cs
@@ -37,12 +37,7 @@ namespace WindowsFormsUI
 
                     _affectivaService.ProcessPhoto(selectedFileName);
 
-                    AddMood addMood = new AddMood
-                    {
-                        MoodCollection = _affectivaService.GetMoodCollection(),
-                    };
-
-                    _moodService.AddMood(sessionId, addMood);
+                    _moodService.AddMood(sessionId, _affectivaService.GetMoodCollection());
                 }
             }
             MessageBox.Show("Photo uploaded successfully!");

--- a/MoodDetector/WindowsFormsUI/StartSessionForm.cs
+++ b/MoodDetector/WindowsFormsUI/StartSessionForm.cs
@@ -34,7 +34,7 @@ namespace WindowsFormsUI
                 
             };
 
-            int sessionId = _moodService.AddClassMood(sessionInfo);
+            int sessionId = _moodService.AddSession(sessionInfo);
             SessionForm sessionForm = new SessionForm(sessionId, _moodService, userForm);
             sessionForm.Show();
             this.Close();

--- a/MoodDetector/WindowsFormsUI/StartSessionForm.cs
+++ b/MoodDetector/WindowsFormsUI/StartSessionForm.cs
@@ -1,10 +1,7 @@
 ﻿using Controller.Service;
 using Model;
 using Model.Entity;
-using System;
 using System.Windows.Forms;
-using System.Drawing;
-using System.Collections.Generic;
 
 namespace WindowsFormsUI
 {
@@ -36,7 +33,9 @@ namespace WindowsFormsUI
                 MessageSeen = 0
                 
             };
-            SessionForm sessionForm = new SessionForm(sessionInfo, _moodService, userForm);
+
+            int sessionId = _moodService.AddClassMood(sessionInfo);
+            SessionForm sessionForm = new SessionForm(sessionId, _moodService, userForm);
             sessionForm.Show();
             this.Close();
         }


### PR DESCRIPTION
Previously every time a new mood was added there was also a new session to go with it.
Now session information is added once per started session.

Renamed table ClassMood to Session since it better represents the information stored.

Test for the new query.